### PR TITLE
Fixes an issue with a Saga not being able to send a message to itself

### DIFF
--- a/gbus/saga/instance.go
+++ b/gbus/saga/instance.go
@@ -30,18 +30,12 @@ func (si *Instance) invoke(exchange, routingKey string, invocation gbus.Invocati
 	}
 
 	valueOfMessage := reflect.ValueOf(message)
-	sginv := &sagaInvocation{
-		decoratedBus:        invocation.Bus(),
-		decoratedInvocation: invocation,
-		inboundMsg:          message,
-		sagaID:              si.ID,
-		ctx:                 invocation.Ctx(),
-	}
+
 	reflectedVal := reflect.ValueOf(si.UnderlyingInstance)
 
 	for _, methodName := range methodsToInvoke {
 		params := make([]reflect.Value, 0)
-		params = append(params, reflect.ValueOf(sginv), valueOfMessage)
+		params = append(params, reflect.ValueOf(invocation), valueOfMessage)
 		method := reflectedVal.MethodByName(methodName)
 		log.Printf(" invoking method %v on saga instance %v", methodName, si.ID)
 		returns := method.Call(params)


### PR DESCRIPTION
The setting of the SagaCorrelationID field on the outgoing message was
flawd in a way that when a saga instance sent a message targeting itself
(sending a command/reply to the same service running the saga) the field
was not set. we assume that if the service the message is being sent to
is the same service that is executing the saga the saga may be targeting
itself and we set message.SagaCorrelationID = message.SagaID

Closes #64