### PR TITLE
fixing a bug in which all handler retires executed within the same

### DIFF
--- a/gbus/worker.go
+++ b/gbus/worker.go
@@ -315,61 +315,31 @@ func (worker *worker) processMessage(delivery amqp.Delivery, isRPCreply bool) {
 		return
 	}
 
-	var tx *sql.Tx
-	var txErr error
-	if worker.isTxnl {
-		tx, txErr = worker.txProvider.New()
-		if txErr != nil {
-			worker.log().WithError(txErr).Error("failed to create transaction")
-			worker.span.LogFields(slog.Error(txErr))
-			//reject the message but requeue it so it gets redelivered until we can create transactions
-			_ = worker.reject(true, delivery)
-			return
-		}
-	}
-	err = worker.invokeHandlers(ctx, handlers, bm, &delivery, tx)
-
-	// if all handlers executed with out errors then commit the transactional if the bus is transactional
-	// if the tranaction committed successfully then ack the message.
-	// if the bus is not transactional then just ack the message
+	err = worker.invokeHandlers(ctx, handlers, bm, &delivery)
 	if err == nil {
-		if worker.isTxnl {
-			err = worker.SafeWithRetries(tx.Commit, MaxRetryCount)
-			if err == nil {
-				worker.log().Info("bus transaction committed successfully ")
-				//ack the message
-				_ = worker.ack(delivery)
-			} else {
-				worker.span.LogFields(slog.Error(err))
-				worker.log().WithError(err).Error("failed committing transaction")
-				//if the commit failed we will reject the message
-				_ = worker.reject(false, delivery)
-			}
-		} else { /*if the bus in not transactional just try acking the message*/
-			_ = worker.ack(delivery)
-		}
-		//else there was an error in the invokation then try rollingback the transaction and reject the message
+		_ = worker.ack(delivery)
 	} else {
-		worker.span.LogFields(slog.Error(err))
-		worker.log().WithError(err).WithFields(log.Fields{"message_name": bm.PayloadFQN, "semantics": bm.Semantics}).Error("Failed to consume message due to failure of one or more handlers.\n Message rejected as poison")
-
-		if worker.isTxnl {
-			worker.log().Warn("rolling back transaction")
-			err = worker.SafeWithRetries(tx.Rollback, MaxRetryCount)
-
-			if err != nil {
-				worker.span.LogFields(slog.Error(err))
-				worker.log().WithError(err).Error("failed to rollback transaction")
-			}
-		}
-
 		_ = worker.reject(false, delivery)
 	}
 }
 
-func (worker *worker) invokeHandlers(sctx context.Context, handlers []MessageHandler, message *BusMessage, delivery *amqp.Delivery, tx *sql.Tx) (err error) {
+func (worker *worker) invokeHandlers(sctx context.Context, handlers []MessageHandler, message *BusMessage, delivery *amqp.Delivery) (err error) {
+
+	//this is the action that will get retried
+	// each retry shoukd run a new and sperate transaction which should end with a commit or rollback
 
 	action := func(attempts uint) (actionErr error) {
+		var tx *sql.Tx
+		var txCreateErr error
+		if worker.isTxnl {
+			tx, txCreateErr = worker.txProvider.New()
+			if txCreateErr != nil {
+				worker.log().WithError(txCreateErr).Error("failed creating new tx")
+				worker.span.LogFields(slog.Error(txCreateErr))
+				return txCreateErr
+			}
+		}
+
 		worker.span, sctx = opentracing.StartSpanFromContext(sctx, "invokeHandlers")
 		worker.span.LogFields(slog.Uint64("attempt", uint64(attempts+1)))
 		defer func() {
@@ -377,6 +347,12 @@ func (worker *worker) invokeHandlers(sctx context.Context, handlers []MessageHan
 				pncMsg := fmt.Sprintf("%v\n%s", p, debug.Stack())
 				worker.log().WithField("stack", pncMsg).Error("recovered from panic while invoking handler")
 				actionErr = errors.New(pncMsg)
+				if worker.isTxnl {
+					rbkErr := tx.Rollback()
+					if rbkErr != nil {
+						worker.log().WithError(rbkErr).Error("failed rolling back transaction when recovering from handler panic")
+					}
+				}
 				worker.span.LogFields(slog.Error(actionErr))
 			}
 			worker.span.Finish()
@@ -393,10 +369,23 @@ func (worker *worker) invokeHandlers(sctx context.Context, handlers []MessageHan
 				ctx:         hsctx,
 				exchange:    delivery.Exchange,
 				routingKey:  delivery.RoutingKey}
-			e := handler(ctx, message)
-			if e != nil {
-				hspan.LogFields(slog.Error(e))
-				return e
+			handlerErr := handler(ctx, message)
+			if handlerErr != nil {
+				hspan.LogFields(slog.Error(handlerErr))
+				if worker.isTxnl {
+					rbkErr := tx.Rollback()
+					if rbkErr != nil {
+						worker.log().WithError(rbkErr).Error("failed rolling back transaction when recovering from handler error")
+					}
+				}
+				return handlerErr
+			}
+		}
+		if worker.isTxnl {
+			cmtErr := tx.Commit()
+			if cmtErr != nil {
+				worker.log().WithError(cmtErr).Error("failed commiting transaction after invoking handlers")
+				return cmtErr
 			}
 		}
 		return nil


### PR DESCRIPTION
transaction

When a handler fails and gets retried each retry should be run in a new
transaction

Closes #81 