### PR TITLE
closing rows when querying transactional outbox fails

### DIFF
--- a/gbus/tx/mysql/txoutbox.go
+++ b/gbus/tx/mysql/txoutbox.go
@@ -241,7 +241,10 @@ func (outbox *TxOutbox) sendMessages(recordSelector func(tx *sql.Tx) (*sql.Rows,
 
 	if selectErr != nil {
 		outbox.log().WithError(selectErr).Error("failed fetching messages from outbox")
-
+		err := rows.Close()
+		if err != nil {
+			outbox.log().WithError(err).Error("could not close Rows")
+		}
 		return selectErr
 	}
 


### PR DESCRIPTION
When failing to query the outbox tables there was no call to rows.Close
potentially causing a connection leak.
Closes #90 