### PR TITLE
sanitize migrations table name

### DIFF
--- a/gbus/tx/mysql/migrations.go
+++ b/gbus/tx/mysql/migrations.go
@@ -2,8 +2,9 @@ package mysql
 
 import (
 	"database/sql"
+	"regexp"
+	"strings"
 
-	"fmt"
 	"github.com/lopezator/migrator"
 	"github.com/wework/grabbit/gbus/tx"
 )
@@ -86,7 +87,7 @@ func TimoutTableMigration(svcName string) *migrator.Migration {
 
 //EnsureSchema implements Grabbit's migrations strategy
 func EnsureSchema(db *sql.DB, svcName string) {
-	migrationsTable := fmt.Sprintf("grabbitMigrations_%s", svcName)
+	migrationsTable := sanitizedMigrationsTable(svcName)
 
 	migrate, err := migrator.New(migrator.TableName(migrationsTable), migrator.Migrations(
 		OutboxMigrations(svcName),
@@ -100,4 +101,11 @@ func EnsureSchema(db *sql.DB, svcName string) {
 	if err != nil {
 		panic(err)
 	}
+}
+
+func sanitizedMigrationsTable(svcName string) string {
+	var re = regexp.MustCompile(`-|;|\\|`)
+	sanitized := re.ReplaceAllString(svcName, "")
+
+	return strings.ToLower("grabbitMigrations_" + sanitized)
 }

--- a/tests/bus_test.go
+++ b/tests/bus_test.go
@@ -412,6 +412,17 @@ func TestHealthCheck(t *testing.T) {
 	}
 }
 
+func TestSanitizingSvcName(t *testing.T) {
+	svc4 := createNamedBusForTest(testSvc4)
+	err := svc4.Start()
+	if err != nil {
+		t.Error(err.Error())
+	}
+	defer svc4.Shutdown()
+
+	fmt.Println("succeeded sanitizing service name")
+}
+
 func noopTraceContext() context.Context {
 	return context.Background()
 	// tracer := opentracing.NoopTracer{}

--- a/tests/consts.go
+++ b/tests/consts.go
@@ -12,12 +12,14 @@ var connStr string
 var testSvc1 string
 var testSvc2 string
 var testSvc3 string
+var testSvc4 string
 
 func init() {
 	connStr = "amqp://rabbitmq:rabbitmq@localhost"
 	testSvc1 = "testSvc1"
 	testSvc2 = "testSvc2"
 	testSvc3 = "testSvc3"
+	testSvc4 = "test-svc4"
 }
 
 func createBusWithConfig(svcName string, deadletter string, txnl, pos bool, conf gbus.BusConfiguration) gbus.Bus {


### PR DESCRIPTION
currently, the migrations table name is composed of the service name. this name needs to be sanitized before using the service name for creating the migrations table.