### PR TITLE
Saga ID can now be generated when the saga first starts

### DIFF
--- a/gbus/abstractions.go
+++ b/gbus/abstractions.go
@@ -123,7 +123,7 @@ type Saga interface {
 }
 
 type SagaIDProvider interface {
-	GetSagaId(invocation Invocation, message *BusMessage) (string, error)
+	GetSagaId(message *BusMessage) (string, error)
 }
 
 //Deadlettering provides the ability to handle messages that were rejected as poision and arrive to the deadletter queue

--- a/gbus/abstractions.go
+++ b/gbus/abstractions.go
@@ -122,8 +122,8 @@ type Saga interface {
 	New() Saga
 }
 
-type SagaIDGenerator interface {
-	GenSagaId(invocation Invocation, message *BusMessage) (string, error)
+type SagaIDProvider interface {
+	GetSagaId(invocation Invocation, message *BusMessage) (string, error)
 }
 
 //Deadlettering provides the ability to handle messages that were rejected as poision and arrive to the deadletter queue

--- a/gbus/abstractions.go
+++ b/gbus/abstractions.go
@@ -122,9 +122,13 @@ type Saga interface {
 	New() Saga
 }
 
-type SagaIDProvider interface {
-	GetSagaId(message *BusMessage) (string, error)
+// CustomSagaCorrelation allows any saga which implements this interface to generate it's own Saga ID from a message
+type CustomSagaCorrelation interface {
+	GetSagaCorrelationFn() SagaCorrelationGetId
 }
+
+// SagaCorrelationGetId custom handler which knows how to convert a message to SagaId/SagaCorrelationId
+type SagaCorrelationGetId func(message *BusMessage, isNew bool) (string, error)
 
 //Deadlettering provides the ability to handle messages that were rejected as poision and arrive to the deadletter queue
 type Deadlettering interface {

--- a/gbus/abstractions.go
+++ b/gbus/abstractions.go
@@ -122,6 +122,10 @@ type Saga interface {
 	New() Saga
 }
 
+type SagaIDGenerator interface {
+	GenSagaId(invocation Invocation, message *BusMessage) (string, error)
+}
+
 //Deadlettering provides the ability to handle messages that were rejected as poision and arrive to the deadletter queue
 type Deadlettering interface {
 	/*

--- a/gbus/messages.go
+++ b/gbus/messages.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/opentracing/opentracing-go/log"
 	"github.com/rs/xid"
+	"github.com/sirupsen/logrus"
 	"github.com/streadway/amqp"
 )
 
@@ -106,6 +107,33 @@ func (bm *BusMessage) GetTraceLog() (fields []log.Field) {
 		log.String("SagaCorrelationID", bm.SagaCorrelationID),
 		log.String("Semantics", string(bm.Semantics)),
 		log.String("RPCID", bm.RPCID),
+	}
+}
+
+func (bm *BusMessage) GetLogFields() (fields logrus.Fields) {
+	return logrus.Fields{
+		"message":           bm.PayloadFQN,
+		"ID":                bm.ID,
+		"IdempotencyKey":    bm.IdempotencyKey,
+		"SagaID":            bm.SagaID,
+		"CorrelationID":     bm.CorrelationID,
+		"SagaCorrelationID": bm.SagaCorrelationID,
+		"Semantics":         string(bm.Semantics),
+		"RPCID":             bm.RPCID,
+	}
+}
+
+// GetFieldsMap returns a map of all of the fields of the message
+func (bm *BusMessage) GetFieldsMap() map[string]string {
+	return map[string]string{
+		"message":           bm.PayloadFQN,
+		"ID":                bm.ID,
+		"IdempotencyKey":    bm.IdempotencyKey,
+		"SagaID":            bm.SagaID,
+		"CorrelationID":     bm.CorrelationID,
+		"SagaCorrelationID": bm.SagaCorrelationID,
+		"Semantics":         string(bm.Semantics),
+		"RPCID":             bm.RPCID,
 	}
 }
 

--- a/gbus/saga/def.go
+++ b/gbus/saga/def.go
@@ -19,12 +19,13 @@ type MsgToFuncPair struct {
 
 //Def defines a saga type
 type Def struct {
-	glue        *Glue
-	sagaType    reflect.Type
-	startedBy   []string
-	lock        *sync.Mutex
-	sagaConfFns []gbus.SagaConfFn
-	msgToFunc   []*MsgToFuncPair
+	glue             *Glue
+	sagaType         reflect.Type
+	startedBy        []string
+	lock             *sync.Mutex
+	sagaConfFns      []gbus.SagaConfFn
+	msgToFunc        []*MsgToFuncPair
+	correlationIdGen gbus.SagaCorrelationGetId
 }
 
 //HandleMessage implements HandlerRegister interface

--- a/gbus/saga/instance.go
+++ b/gbus/saga/instance.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/opentracing/opentracing-go"
-	"github.com/rs/xid"
 	"github.com/sirupsen/logrus"
 
 	"github.com/wework/grabbit/gbus"
@@ -149,7 +148,6 @@ func NewInstance(sagaType reflect.Type, msgToMethodMap []*MsgToFuncPair) *Instan
 
 	//newSagaPtr := reflect.New(sagaType).Elem()
 	newInstance := &Instance{
-		ID:                 xid.New().String(),
 		UnderlyingInstance: newSaga,
 		MsgToMethodMap:     msgToMethodMap,
 	}

--- a/gbus/saga/instance.go
+++ b/gbus/saga/instance.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/opentracing/opentracing-go"
+	"github.com/rs/xid"
 	"github.com/sirupsen/logrus"
 
 	"github.com/wework/grabbit/gbus"
@@ -148,6 +149,7 @@ func NewInstance(sagaType reflect.Type, msgToMethodMap []*MsgToFuncPair) *Instan
 
 	//newSagaPtr := reflect.New(sagaType).Elem()
 	newInstance := &Instance{
+		ID:                 xid.New().String(),
 		UnderlyingInstance: newSaga,
 		MsgToMethodMap:     msgToMethodMap,
 	}

--- a/gbus/saga/instance.go
+++ b/gbus/saga/instance.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/opentracing/opentracing-go"
-	"github.com/rs/xid"
 	"github.com/sirupsen/logrus"
+
 	"github.com/wework/grabbit/gbus"
 	"github.com/wework/grabbit/gbus/metrics"
 )
@@ -148,7 +148,6 @@ func NewInstance(sagaType reflect.Type, msgToMethodMap []*MsgToFuncPair) *Instan
 
 	//newSagaPtr := reflect.New(sagaType).Elem()
 	newInstance := &Instance{
-		ID:                 xid.New().String(),
 		UnderlyingInstance: newSaga,
 		MsgToMethodMap:     msgToMethodMap,
 	}

--- a/gbus/tx/sagastore.go
+++ b/gbus/tx/sagastore.go
@@ -251,4 +251,3 @@ func GetSagatableName(svcName string) string {
 
 	return strings.ToLower("grabbit_" + sanitized + "_sagas")
 }
-

--- a/tests/metrics_test.go
+++ b/tests/metrics_test.go
@@ -130,7 +130,7 @@ func TestRunHandlerWithMetric_Latency(t *testing.T) {
 	}
 }
 
-func checkLatency(t *testing.T, sc  *uint64, expected uint64, err error) {
+func checkLatency(t *testing.T, sc *uint64, expected uint64, err error) {
 	if err != nil {
 		t.Errorf("Failed to get latency value: %e", err)
 	}

--- a/tests/saga_test.go
+++ b/tests/saga_test.go
@@ -409,7 +409,7 @@ func TestSetSagaIdFromMessage(t *testing.T) {
 	defer client.Shutdown()
 
 	client2.Start()
-	defer client.Shutdown()
+	defer client2.Shutdown()
 
 	response, err := client.RPC(context.Background(), testSvc1, gbus.NewBusMessage(Command1{
 		Data: "vlad",

--- a/tests/saga_test.go
+++ b/tests/saga_test.go
@@ -660,7 +660,7 @@ type IdGenerationSaga struct {
 	Complete bool
 }
 
-func (i *IdGenerationSaga) GetSagaId(invocation gbus.Invocation, message *gbus.BusMessage) (string, error) {
+func (i *IdGenerationSaga) GetSagaId(message *gbus.BusMessage) (string, error) {
 	switch msg := message.Payload.(type) {
 	case *Command1:
 		return msg.Data, nil

--- a/tests/saga_test.go
+++ b/tests/saga_test.go
@@ -636,13 +636,13 @@ func (s *ConfigurableSaga) New() gbus.Saga {
 }
 
 var _ gbus.Saga = &IdGenerationSaga{}
-var _ gbus.SagaIDGenerator = &IdGenerationSaga{}
+var _ gbus.SagaIDProvider = &IdGenerationSaga{}
 
 type IdGenerationSaga struct {
 	Complete bool
 }
 
-func (i *IdGenerationSaga) GenSagaId(invocation gbus.Invocation, message *gbus.BusMessage) (string, error) {
+func (i *IdGenerationSaga) GetSagaId(invocation gbus.Invocation, message *gbus.BusMessage) (string, error) {
 	msg, ok := message.Payload.(*Command1)
 	if !ok {
 		return "", errors.NewWithDetails("could not cast message.Payload to Command1", "payload", message.Payload)


### PR DESCRIPTION
If a saga implements `gbus.SagaIDGenerator` it will be able to generate it's own ID instead of the auto generated one by grabbbit